### PR TITLE
added a .zenodo.json file to control metadata on Zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,44 @@
+{
+    "description": "FIXME",
+    "license": "FIXME",
+    "title": "FIXME",
+    "upload_type": "software",
+    "creators": [
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Werkhoven, Ben"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Kuzniar, Arnold",
+            "orcid": "0000-0003-1711-7961"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Georgievska, Sonja"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Gavai, Anand"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Sclocco, Alessio"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Bakhshi, Rena"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Spreeuw, Hanno"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+          "cluster analysis",
+          "FIXME",
+          "FIXME",
+          "etc"
+    ]
+}


### PR DESCRIPTION
Hey I'm experimenting a bit with controlling the metadata that gets attached to your releases on Zenodo. In this PR, I've added a new file ``.zenodo.json`` which now includes the contributors from https://github.com/nlesc-sherlock/graphs/contributors as ``creators``. If you also want to include people who make issues and pull requests and such, there is another field ``contributors`` you can add to the ``.zenodo.json``. Items you include there can have an attribute ``type`` which you can set to ``Other`` or another type from the controlled vocabulary [ContactPerson, DataCollector, DataCurator, DataManager, Editor, Researcher, RightsHolder, Sponsor, Other]. 

Anyway long story short, with this ``.zenodo.json`` file, your release process should be less painful.
-Jurriaan

PS Note that the ``.zenodo.json`` file still needs work; I've added as much data as I could from the github repo, but there currently isn't much metadata to work with.